### PR TITLE
Support markdown in subdirs

### DIFF
--- a/goremark.go
+++ b/goremark.go
@@ -63,11 +63,19 @@ func getHomeDirPath() string {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	b, err := ioutil.ReadFile(*file)
-	if err != nil {
-		fmt.Fprintf(w, "Error:\n\n", err)
+	path := r.URL.Path[1:]
+	if path == "" {
+		// Serve the wrapped markdown.
+		b, err := ioutil.ReadFile(*file)
+		if err != nil {
+			fmt.Fprintf(w, "Error:\n\n", err)
+		} else {
+			fmt.Fprint(w, header+string(b)+footer)
+		}
 	} else {
-		fmt.Fprint(w, header+string(b)+footer)
+		// Accommodate static files when the markdown is within a
+		// subdirectory.
+		http.Redirect(w, r, "/"+*static+"/"+path, http.StatusFound)
 	}
 }
 


### PR DESCRIPTION
Previously static content failed to render if the markdown was in a
subfolder, but the static content was also in that subfolder and
referenced with a relative path.
